### PR TITLE
Fix Dockerfile QUARKUS_EXTENSION dep and clean arg.conf files

### DIFF
--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -13,7 +13,7 @@ FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builde
 # When using nightly:
 # ARG QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT,org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.8.4,io.quarkus:quarkus-agroal:3.8.4,org.kie:kie-addons-quarkus-monitoring-prometheus:999-SNAPSHOT,org.kie:kie-addons-quarkus-monitoring-sonataflow:999-SNAPSHOT
 # When using prod:
-ARG QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:9.102.0.redhat-00004,org.kie:kie-addons-quarkus-persistence-jdbc:9.102.0.redhat-00004,io.quarkus:quarkus-jdbc-postgresql:3.8.6.redhat-00004,io.quarkus:quarkus-agroal:3.8.6.redhat-00004
+ARG QUARKUS_EXTENSIONS=org.kie:kie-addons-quarkus-monitoring-sonataflow:10.0.0,org.kie:kogito-addons-quarkus-jobs-knative-eventing:10.0.0,org.kie:kie-addons-quarkus-persistence-jdbc:10.0.0,io.quarkus:quarkus-jdbc-postgresql:3.8.6.redhat-00004,io.quarkus:quarkus-agroal:3.8.6.redhat-00004
 
 # Args to pass to the Quarkus CLI
 # add extension command

--- a/workflows/create-ocp-project/argfile.conf
+++ b/workflows/create-ocp-project/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=create-ocp-project Serverless Workflow
 FLOW_SUMMARY=create-ocp-project Serverless Workflow
 FLOW_DESCRIPTION=create-ocp-project workflow consumes a source code repo and pushes a branch with manifests and build files to containerize and application

--- a/workflows/escalation/argfile.conf
+++ b/workflows/escalation/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=escalation
 FLOW_SUMMARY=Ticket escalation workflow
 FLOW_DESCRIPTION=Ticket escalation workflow

--- a/workflows/escalation/jira-listener/argfile.conf
+++ b/workflows/escalation/jira-listener/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=jira-listener
 FLOW_SUMMARY=jira-listener application
 FLOW_DESCRIPTION=jira-listener application

--- a/workflows/greeting/argfile.conf
+++ b/workflows/greeting/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=Greeting
 FLOW_SUMMARY=Greeting workflow
 FLOW_DESCRIPTION=YAML based greeting workflow

--- a/workflows/modify-vm-resources/argfile.conf
+++ b/workflows/modify-vm-resources/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=modify-vm-resources Serverless Workflow
 FLOW_SUMMARY=modify-vm-resources Serverless Workflow
 FLOW_DESCRIPTION=modify-vm-resources workflow consumes a source code repo and pushes a branch with manifests and build files to containerize and application

--- a/workflows/move2kube/argfile.conf
+++ b/workflows/move2kube/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=move2kube Serverless Workflow
 FLOW_SUMMARY=move2kube Serverless Workflow
 FLOW_DESCRIPTION=move2kube workflow consumes a source code repo and pushes a branch with manifests and build files to containerize and application

--- a/workflows/mta-v7.x/argfile.conf
+++ b/workflows/mta-v7.x/argfile.conf
@@ -1,9 +1,4 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
 # QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT,org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.8.4,io.quarkus:quarkus-agroal:3.8.4,org.kie:kie-addons-quarkus-monitoring-prometheus:999-SNAPSHOT,org.kie:kie-addons-quarkus-monitoring-sonataflow:999-SNAPSHOT
-
 FLOW_NAME=MTA v7.x Serverless Workflow
 FLOW_SUMMARY=MTA v7.x Serverless Workflow
 FLOW_DESCRIPTION=MTA v7.x workflow consumes a source code repo and asses if it can be migrated

--- a/workflows/mtv-migration/argfile.conf
+++ b/workflows/mtv-migration/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=MTV migration workflow
 FLOW_SUMMARY=MTV migration workflow
 FLOW_DESCRIPTION=The workflow executes a plan by creating a migration and waiting for it to be successful or failed

--- a/workflows/mtv-plan/argfile.conf
+++ b/workflows/mtv-plan/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=MTV plan workflow
 FLOW_SUMMARY=MTV plan assessment workflow
 FLOW_DESCRIPTION=An assessment workflow that creates a plan and waits for it to be ready or failed

--- a/workflows/request-vm-cnv/argfile.conf
+++ b/workflows/request-vm-cnv/argfile.conf
@@ -1,8 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
-
 FLOW_NAME=request-vm-cnv Serverless Workflow
 FLOW_SUMMARY=request-vm-cnv Serverless Workflow
 FLOW_DESCRIPTION=request-vm-cnv workflow consumes a source code repo and pushes a branch with manifests and build files to containerize and application

--- a/workflows/rpj/argfile.conf
+++ b/workflows/rpj/argfile.conf
@@ -1,7 +1,3 @@
-BUILDER_IMAGE=
-
-# FIXME Adding monitoring jar fails the build org.kie.kogito:kogito-addons-monitoring-prometheus:1.13.2.redhat-00011
-QUARKUS_EXTENSIONS=
 FLOW_NAME=RPJ
 FLOW_SUMMARY=RPJ serverless workflow consumes a launch ID from the Report Portal and creates a Jira task
 FLOW_DESCRIPTION=RPJ serverless workflow consumes a launch ID from the Report Portal and creates a Jira task


### PR DESCRIPTION
Fix Dockerfile QUARKUS_EXTENSION dep and clean arg.conf file: because of the empty `QUARKUS_EXTENSION` value in the arg.conf files, the value defined in the Dockerfile were ignored. This PR removes empty values from the arg.conf files to avoid those issue

This PR also fixes the versions of the `QUARKUS_EXTENSION` dependencies

