### PR TITLE
changing parodos-dev to rhdhorchestrator in some links - v1.4

### DIFF
--- a/workflows/move2kube/README.md
+++ b/workflows/move2kube/README.md
@@ -49,7 +49,7 @@ The use case has the following components:
 
 ## Installation
 
-See [official installation guide](https://github.com/parodos-dev/serverless-workflows-config/blob/main/docs/main/move2kube)
+See [official installation guide](https://github.com/rhdhorchestrator/serverless-workflows-config/blob/main/docs/main/move2kube)
 
 ## Usage
 1. Create a workspace and a project under it in your move2kube instance

--- a/workflows/mtv-migration/README.md
+++ b/workflows/mtv-migration/README.md
@@ -20,7 +20,7 @@ Application properties can be initialized from environment variables before runn
 
 ## Installation
 
-See [official installation guide](https://github.com/parodos-dev/serverless-workflows-config/blob/main/docs/main/mtv-migration)
+See [official installation guide](https://github.com/rhdhorchestrator/serverless-workflows-config/blob/main/docs/main/mtv-migration)
 
 ## How to run
 Example of POST to trigger the flow (see input schema [mtv-input.json](./schema/mtv-input.json)):

--- a/workflows/mtv-plan/README.md
+++ b/workflows/mtv-plan/README.md
@@ -20,7 +20,7 @@ Application properties can be initialized from environment variables before runn
 
 ## Installation
 
-See [official installation guide](https://github.com/parodos-dev/serverless-workflows-config/blob/main/docs/main/mtv-plan)
+See [official installation guide](https://github.com/rhdhorchestrator/serverless-workflows-config/blob/main/docs/main/mtv-plan)
 
 
 ## How to run

--- a/workflows/rpj/README.md
+++ b/workflows/rpj/README.md
@@ -18,7 +18,7 @@ In this project, a side proxy application was created in order to avoid self-sig
 If you RPJ is configured properly (i.e: without self-signed certificates), you can remove the proxy application.
 
 # Workflow Diagram
-![rpj workflow diagram](https://github.com/parodos-dev/serverless-workflows/blob/main/rpj/rpj.svg?raw=true)
+![rpj workflow diagram](https://github.com/rhdhorchestrator/serverless-workflows/blob/main/rpj/rpj.svg?raw=true)
 
 # Workflow application configuration
 Application properties can be initialized from environment variables before running the application:

--- a/workflows/rpj/rpj.sw.yaml
+++ b/workflows/rpj/rpj.sw.yaml
@@ -17,7 +17,7 @@ extensions:
     outputSchema: schemas/workflow-output-schema.json
   - extensionid: workflow-uri-definitions
     definitions:
-      notifications: "https://raw.githubusercontent.com/parodos-dev/serverless-workflows/main/workflows/shared/specs/notifications-openapi.yaml"
+      notifications: "https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows/main/workflows/shared/specs/notifications-openapi.yaml"
 functions:
   - name: run
     operation: specs/rpj.json#run


### PR DESCRIPTION
(in v1.4)
This PR will change some old links that use 'parodos-dev' to rhdhorchestrator
And will close this bug:
https://issues.redhat.com/browse/FLPATH-2082