### PR TITLE
Adding deprecation notice for assessment workflows

### DIFF
--- a/best-practices.md
+++ b/best-practices.md
@@ -1,3 +1,7 @@
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> Any reference to assessment workflows in this document will be obsolete. 
+
 # Best practices when creating a workflow
 A workflow should be developed in accordance with the guidelines outlined in the [Serverless Workflow definitions][1] documentation.
 

--- a/workflows/mta-v7.x/README.md
+++ b/workflows/mta-v7.x/README.md
@@ -1,3 +1,7 @@
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> This workflow, being an assessment workflow, will be obsolete and irrelevant. 
+
 # MTA - migration analysis workflow
 
 # Synopsis

--- a/workflows/mtv-migration/README.md
+++ b/workflows/mtv-migration/README.md
@@ -1,3 +1,7 @@
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> This workflow is a continuation of an assessment workflow. Therfore, that workflow will be obsolete and won't server as a perliminary to this one. 
+
 # MTV migration workflow - MTV Migration execution workflow
 This workflow is a continuation of the MTV assessment workflow. It executes an MTV Plan and waits for its final condition. Final condition is either success or failure. It is important to note that we rely on MTV to reach a final state. We do not impose our own timeout.
 [MTV Migration Plan documentation](https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#creating-migration-plans-ui)

--- a/workflows/mtv-plan/README.md
+++ b/workflows/mtv-plan/README.md
@@ -1,3 +1,7 @@
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> This workflow, being an assessment workflow, will be obsolete and irrelevant. 
+
 # MTV assessment - MTV Plan assessment workflow
 This workflow is an assessment workflow type, that creates an MTV Plan resource and waits for its final condition. Final condition is either success or failure. It is important to note that we rely on MTV to reach a final state. We do not impose our own timeout.
 [MTV Migration Plan documentation](https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#creating-migration-plans-ui)


### PR DESCRIPTION
This PR is part of the deprecation of Assessment workflows in Orchestrator.
Specifically, related to this story: https://issues.redhat.com/browse/FLPATH-2328
