### PR TITLE
Updating repository to OSL-1.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ prepare-workdir:
 ifeq ($(IS_WORKFLOW),true)
 build-image: BUILD_ARGS=--build-arg-file=workflows/$(WORKFLOW_ID)/argfile.conf --build-arg=BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg WF_RESOURCES=workflows/$(WORKFLOW_ID)
 endif
-build-image: EXTRA_ARGS=--ulimit nofile=4096:4096
+build-image: EXTRA_ARGS=--ulimit nofile=4096:4096 --platform='linux/amd64'
 build-image: prepare-workdir
 	@echo "Building $(IMAGE_NAME)"
 ifeq ($(IS_APPLICATION),true)

--- a/pipeline/workflow-builder.Dockerfile
+++ b/pipeline/workflow-builder.Dockerfile
@@ -4,7 +4,15 @@
 ARG BUILDER_IMAGE
 
 # The default builder image is the latest publicly released OSL https://catalog.redhat.com/software/containers/openshift-serverless-1/logic-swf-builder-rhel8/6614edd826a5be569c111884?container-tabs=gti
-FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8@sha256:5590b799420769ee2fe316bc0425bec10f7a29433765244702a23348150e621e} AS builder
+# Official Red Hat OpenShift Serverless Logic SWF Builder image
+#FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8@sha256:5590b799420769ee2fe316bc0425bec10f7a29433765244702a23348150e621e} AS builder
+
+# Midstream builder image
+# This image is used for development and testing purposes, and is not intended for production use.
+#FROM ${BUILDER_IMAGE:-quay.io/kubesmarts/incubator-kie-sonataflow-builder:9.103.x-prod} AS builder
+
+# Image used for disconnected environments, with JDBC and PostgreSQL support included, based on the latest OSL builder image
+FROM ${BUILDER_IMAGE:-quay.io/orchestrator/logic-swf-builder-rhel8:1.36.0-rc1-disconnected} AS builder
 
 #ENV MAVEN_REPO_URL=https://maven.repository.redhat.com/earlyaccess/all
 
@@ -13,7 +21,7 @@ FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builde
 # When using nightly:
 # ARG QUARKUS_EXTENSIONS=org.kie:kogito-addons-quarkus-jobs-knative-eventing:999-SNAPSHOT,org.kie:kie-addons-quarkus-persistence-jdbc:999-SNAPSHOT,io.quarkus:quarkus-jdbc-postgresql:3.8.4,io.quarkus:quarkus-agroal:3.8.4,org.kie:kie-addons-quarkus-monitoring-prometheus:999-SNAPSHOT,org.kie:kie-addons-quarkus-monitoring-sonataflow:999-SNAPSHOT
 # When using prod:
-ARG QUARKUS_EXTENSIONS=io.quarkiverse.openapi.generator:quarkus-openapi-generator:2.9.1-lts,org.kie:kie-addons-quarkus-monitoring-sonataflow:10.0.0,org.kie:kogito-addons-quarkus-jobs-knative-eventing:10.0.0,org.kie:kie-addons-quarkus-persistence-jdbc:10.0.0,io.quarkus:quarkus-jdbc-postgresql:3.8.6,io.quarkus:quarkus-agroal:3.8.6
+ARG QUARKUS_EXTENSIONS=io.quarkiverse.openapi.generator:quarkus-openapi-generator:2.9.1-lts,org.kie:kie-addons-quarkus-monitoring-sonataflow,org.kie:kogito-addons-quarkus-jobs-knative-eventing,org.kie:kie-addons-quarkus-persistence-jdbc,io.quarkus:quarkus-jdbc-postgresql:3.15.4.redhat-00001,io.quarkus:quarkus-agroal:3.15.4.redhat-00001
 
 # Args to pass to the Quarkus CLI
 # add extension command

--- a/scripts/gen_manifests.sh
+++ b/scripts/gen_manifests.sh
@@ -18,11 +18,11 @@ command -v kubectl
 
 cd "${WORKFLOW_FOLDER}"
 
-echo -e "\nquarkus.flyway.migrate-at-start=true" >> application.properties
+echo -e "\nkie.flyway.enabled=true" >> application.properties
 
-# TODO Update to use --skip-namespace when the following is released
-# https://github.com/apache/incubator-kie-tools/pull/2136
-kn-workflow gen-manifest --namespace ""
+kn-workflow gen-manifest --profile='gitops' \
+        --image="${WORKFLOW_IMAGE_REGISTRY}/${WORKFLOW_IMAGE_NAMESPACE}/${WORKFLOW_IMAGE_REPO}:${WORKFLOW_IMAGE_TAG}" \
+        --namespace=""
 
 # Enable bash's extended blobing for better pattern matching
 shopt -s extglob
@@ -49,15 +49,9 @@ fi
 # the main sonataflow file will have a prefix of variable number, 01 or 02 and so on, because manifests created by
 # gen-manifests are now sorted by name. We need to take *-sonataflow-$workflow_id.yaml to resolve that.
 SONATAFLOW_CR=$(printf '%s' manifests/*-sonataflow_"${workflow_id}".yaml)
-yq --inplace eval '.metadata.annotations["sonataflow.org/profile"] = "gitops"' "${SONATAFLOW_CR}"
 
-yq --inplace ".spec.podTemplate.container.image=\"${WORKFLOW_IMAGE_REGISTRY}/${WORKFLOW_IMAGE_NAMESPACE}/${WORKFLOW_IMAGE_REPO}:${WORKFLOW_IMAGE_TAG}\"" "${SONATAFLOW_CR}"
-
-if test -f "secret.properties"; then
-  yq --inplace ".spec.podTemplate.container.envFrom=[{\"secretRef\": { \"name\": \"${workflow_id}-creds\"}}]" "${SONATAFLOW_CR}"
-  kubectl create secret generic "${workflow_id}-creds" --from-env-file=secret.properties --dry-run=client -oyaml > "manifests/00-secret_${workflow_id}.yaml"
-fi
-
+# The following properties are set in the Sonataflow CR, for each workflow to enable persistence.
+# TODO: It should be replaced with a single definition in the SonataflowPlatform CR
 if [ "${ENABLE_PERSISTENCE}" = true ]; then
     yq --inplace ".spec |= (
       . + {

--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -sSL "https://mirror.openshift.com/pub/openshift-v4/clients/serverless/
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
     && chmod +x kubectl && mv kubectl /usr/local/bin/
 
-RUN curl -LO "https://github.com/rgolangh/kie-tools/releases/download/packages%2Fkn-plugin-workflow%2F0.0.0-69ab19c/kn-workflow-linux-amd64" \
+RUN curl -LO "https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.36.0/kn-workflow-linux-amd64" \
     && chmod +x kn-workflow-linux-amd64 && mv kn-workflow-linux-amd64 /usr/local/bin/kn-workflow

--- a/setup/README.md
+++ b/setup/README.md
@@ -11,8 +11,8 @@ This container images extends a basic UBI 9 image with the required tools:
 # Build and publish the image
 Customize the `push` command to publish in your own repository:
 ```bash
- docker build -t quay.io/$USER/ubi9-pipeline:latest .
- docker push quay.io/$USER/ubi9-pipeline:latest
+ podman build --platform='linux/amd64' -t quay.io/$USER/ubi9-pipeline:latest .
+ podman push quay.io/$USER/ubi9-pipeline:latest
 ```
 # A workflow for building the image
 When the Dockerfile is changed and merged, a [workflow](https://github.com/rhdhorchestrator/serverless-workflows/blob/main/.github/workflows/builder-utility.yaml) is triggered to build and publish the image.

--- a/workflows/create-ocp-project/application.properties
+++ b/workflows/create-ocp-project/application.properties
@@ -14,8 +14,6 @@ quarkus.openapi-generator.ocp_project_openapi_yaml.auth.BearerToken.bearer-token
 quarkus.tls.trust-all=true
 quarkus.kubernetes-client.trust-certs=true
 
-quarkus.flyway.migrate-at-start=true
-
 # This property is used to select the log level, which controls the amount
 # of information logged on HTTP requests based on the severity of the events.
 # Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.

--- a/workflows/greeting/application.properties
+++ b/workflows/greeting/application.properties
@@ -4,4 +4,3 @@
 # and see https://quarkus.io/guides/logging for documentation
 quarkus.log.category."org.apache.http".level=INFO
 quarkus.log.level=INFO
-quarkus.flyway.migrate-at-start=true

--- a/workflows/modify-vm-resources/application.properties
+++ b/workflows/modify-vm-resources/application.properties
@@ -17,8 +17,6 @@ quarkus.openapi-generator.kubevirt_openapi_yaml.auth.BearerToken.bearer-token=${
 quarkus.tls.trust-all=true
 quarkus.kubernetes-client.trust-certs=true
 
-quarkus.flyway.migrate-at-start=true
-
 # This property is used to select the log level, which controls the amount
 # of information logged on HTTP requests based on the severity of the events.
 # Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.

--- a/workflows/request-vm-cnv/application.properties
+++ b/workflows/request-vm-cnv/application.properties
@@ -17,8 +17,6 @@ quarkus.openapi-generator.kubevirt_openapi_yaml.auth.BearerToken.bearer-token=${
 quarkus.tls.trust-all=true
 quarkus.kubernetes-client.trust-certs=true
 
-quarkus.flyway.migrate-at-start=true
-
 # This property is used to select the log level, which controls the amount
 # of information logged on HTTP requests based on the severity of the events.
 # Possible values: OFF, FATAL, ERROR, WARN, INFO, DEBUG, ALL.


### PR DESCRIPTION
Within this PR, we prepare the tools for using OSL 1.36:
* Update builder image to use a custom builder image based on 1.36 with precached dependencies
* Update pipeline image to use kn-workflow 1.36 that introduced some goodies that led to:
* Update scripts that used to hack lack of support in kn-workflow (specify image, profile and generate secrets)
* Update persistence property to its new name

The builder image used in this PR was created by https://github.com/rhdhorchestrator/orchestrator-demo/pull/34
