### PR TITLE
Fix BearerToken header name in workflow application.props

### DIFF
--- a/workflows/experimentals/github-pr/manifests/01-configmap_gh-pr-props.yaml
+++ b/workflows/experimentals/github-pr/manifests/01-configmap_gh-pr-props.yaml
@@ -15,7 +15,7 @@ data:
     #quarkus.openapi-generator.github_yaml.auth.BearerToken.bearer-token=${ghToken}
     quarkus.kogito.devservices.enabled=false
     quarkus.openapi-generator.github_yaml.auth.BearerToken.token-propagation=true
-    quarkus.openapi-generator.github_yaml.auth.BearerToken.header-name=X-GitHub-Authorization
+    quarkus.openapi-generator.github_yaml.auth.BearerToken.header-name=X-Authorization-Github
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/workflows/experimentals/github-pr/src/main/resources/application.properties
+++ b/workflows/experimentals/github-pr/src/main/resources/application.properties
@@ -12,4 +12,4 @@ quarkus.rest-client.github_yaml.url=https://api.github.com
 #quarkus.openapi-generator.github_yaml.auth.BearerToken.bearer-token=${ghToken}
 quarkus.kogito.devservices.enabled=false
 quarkus.openapi-generator.github_yaml.auth.BearerToken.token-propagation=true
-quarkus.openapi-generator.github_yaml.auth.BearerToken.header-name=X-GitHub-Authorization
+quarkus.openapi-generator.github_yaml.auth.BearerToken.header-name=X-Authorization-Github


### PR DESCRIPTION
According to https://issues.redhat.com/browse/FLPATH-2438
The application.props in the workflow needed to be changed to match the correct one. 